### PR TITLE
crud-app load was too high add limits and settings

### DIFF
--- a/.dapr/components/pubsub.yaml
+++ b/.dapr/components/pubsub.yaml
@@ -7,7 +7,7 @@ spec:
   version: v1
   metadata:
   - name: redisHost
-    value: redis-master:6379
+    value: redis-master.crud-app:6379
   - name: redisPassword
     secretKeyRef:
       name: redis

--- a/.dapr/components/state.yaml
+++ b/.dapr/components/state.yaml
@@ -12,7 +12,7 @@ spec:
   # Redis password with your own Secret's name. For more information,
   # see https://docs.dapr.io/operations/components/component-secrets .
   - name: redisHost
-    value: redis-master:6379
+    value: redis-master.crud-app:6379
   - name: redisPassword
     secretKeyRef:
       name: redis

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,6 @@ deploy:
 	kubectl apply -f deploy -n ${APP_NAMESPACE}
 
 apply:
-	kubectl apply -f .dapr/configuration.yaml -n crud-app
-	kubectl apply -f .dapr/components -n crud-app
-	kubectl apply -f deploy -n crud-app
+	kubectl apply -f .dapr/configuration.yaml -n ${APP_NAMESPACE}
+	kubectl apply -f .dapr/components -n ${APP_NAMESPACE}
+	kubectl apply -f deploy -n ${APP_NAMESPACE}

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -16,6 +16,8 @@ func main() {
 	serveFlagSet := flag.NewFlagSet("app serve", flag.ExitOnError)
 	var serverPort *int = serveFlagSet.Int("port", 8080, "port for the server to listen to")
 	var connStr *string = serveFlagSet.String("connStr", "mongodb://localhost:27017", "connection string for storage")
+	var maxItems *int = serveFlagSet.Int("maxItems", 20, "maximum numbers of items to store")
+	var cleanupIntervalSeconds *int = serveFlagSet.Int("cleanupIntervalSeconds", 600, "seconds to wait between cleanup runs")
 
 	serve := &ffcli.Command{
 		Name:     "serve",
@@ -27,16 +29,17 @@ func main() {
 
 			if *connStr == "" || *connStr == "mem" {
 				fmt.Println("Using inmemory storage")
-				s = storage.NewInMemoryStorage()
+				s = storage.NewInMemoryStorage(*maxItems)
 			} else if *connStr == "dapr" {
-				s = storage.NewDaprStorage()
+				s = storage.NewDaprStorage(*maxItems)
 			} else {
-				s = storage.NewMongoStorage(*connStr)
+				s = storage.NewMongoStorage(*connStr, *maxItems)
 			}
 
 			server := server.Server{
-				Port:    *serverPort,
-				Storage: s,
+				Port:                   *serverPort,
+				Storage:                s,
+				CleanupIntervalSeconds: *cleanupIntervalSeconds,
 			}
 			server.Start()
 			return nil

--- a/deploy/crud-app.yaml
+++ b/deploy/crud-app.yaml
@@ -27,6 +27,10 @@ spec:
           - "serve"
           - "-connStr"
           - "dapr"
+          - "-maxItems"
+          - "20"
+          - "-cleanupIntervalSeconds"
+          - "600"
         ports:
         - containerPort: 8080
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,8 +13,9 @@ import (
 )
 
 type Server struct {
-	Port    int
-	Storage s.TodosStorage
+	Port                   int
+	Storage                s.TodosStorage
+	CleanupIntervalSeconds int
 }
 
 func (server *Server) Start() {
@@ -118,7 +119,7 @@ func generateLoad(ctx context.Context, server *Server) {
 }
 
 func cleanup(ctx context.Context, server *Server) {
-	ticker := time.NewTicker(3000 * time.Second)
+	ticker := time.NewTicker(time.Duration(server.CleanupIntervalSeconds) * time.Second)
 
 	for {
 		select {

--- a/pkg/storage/mem.go
+++ b/pkg/storage/mem.go
@@ -6,13 +6,17 @@ import (
 )
 
 type InMemoryStorage struct {
-	all []*todos.Todo
+	all      []*todos.Todo
+	maxItems int
 }
 
 var impl TodosStorage = &InMemoryStorage{}
 
 func (s *InMemoryStorage) Create(todo *todos.Todo) error {
 	todo.Id = uuid.New().String()
+	if len(s.all) >= s.maxItems {
+		s.all = s.all[1:]
+	}
 	s.all = append(s.all, todo)
 	return nil
 }
@@ -29,8 +33,9 @@ func (s *InMemoryStorage) ListAll() ([]*todos.Todo, error) {
 	return s.all, nil
 }
 
-func NewInMemoryStorage() *InMemoryStorage {
+func NewInMemoryStorage(maxItems int) *InMemoryStorage {
 	return &InMemoryStorage{
-		all: []*todos.Todo{},
+		all:      []*todos.Todo{},
+		maxItems: maxItems,
 	}
 }


### PR DESCRIPTION
Add maxItems and cleanupIntervalSeconds flags
Limit the number of todo items stored to reduce serialization overhead 
Dapr storage was creating an index array at an exponential rate filled with empty strings (see log output below)
Add namespace to redis host in components, init was failing when deployed to a different namespace than the agent
Makefile use APP_NAMESPACE env var on apply

Cleanup logs:
```
crud-app-deployment-799cbc555-nll6z crud-app cleaning data
crud-app-deployment-799cbc555-nll6z crud-app allTodos length: 20
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 20
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 38
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: e5ec6a61-66c6-4d4a-87ef-bf7e0ce85d1b
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 38
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 74
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: b8d7bc05-f23b-49b5-bba7-6a3289c8193f
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 74
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 146
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: 00016c6b-0648-4d3c-8391-672d59859170
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 146
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 290
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: deeb7bcb-a56b-4af9-a3f0-ffa09d71909b
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 290
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 578
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: e2e33138-47bc-43eb-9221-c25ec5626e08
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 578
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 1154
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: 1164fba2-1c24-42e0-b5cc-eb0d59ac3907
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 1154
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 2306
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: e7260e4e-69fa-4d82-a683-84f9b300c505
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 2306
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 4610
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: 29288fef-fccf-4c14-a1e5-8a0b5551e46e
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 4610
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 9218
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: 5c808df1-4c6b-4dcc-b739-dfb8cfecbb64
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 9218
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 18434
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: ab43c461-b3e6-4e93-99de-dac973f15ba2
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 18434
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 36866
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: fc25d032-d739-4572-b03b-84155a82af0d
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 36866
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 73730
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: eb61fdd5-fa8c-4a5a-aec7-0b5f165fd9b0
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 73730
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 147458
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: b184b3d6-a32c-44c4-8bd7-74b6cc1f304e
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 147458
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 294914
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: 995709be-7f15-4312-b85b-3346b79d7697
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 294914
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 589826
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: 26e6ef0d-a46a-4127-b063-0886484d5c45
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 589826
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 1179650
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: 4781e4bb-623f-4fe3-b0d2-606e4adb0ade
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 1179650
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 2359298
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: e38644f5-3ffe-4494-8fec-fb47367e0dd3
crud-app-deployment-799cbc555-nll6z crud-app error saving state: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (7078038 vs. 4194304)
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 1179650
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 2359298
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: 437e54d2-393f-4ab9-8399-07b7ee57431c
crud-app-deployment-799cbc555-nll6z crud-app error saving state: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (7078038 vs. 4194304)
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 1179650
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 2359298
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: b2783af4-ca23-4e67-9149-2a4110e27435
crud-app-deployment-799cbc555-nll6z crud-app error saving state: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (7078038 vs. 4194304)
crud-app-deployment-799cbc555-nll6z crud-app allTodos length fetched: 1179650
crud-app-deployment-799cbc555-nll6z crud-app newtodos length created: 2359298
crud-app-deployment-799cbc555-nll6z crud-app deleting todo: c10298ab-8882-496c-be83-c19411def104
crud-app-deployment-799cbc555-nll6z crud-app error saving state: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (7078038 vs. 4194304)
```